### PR TITLE
Added 64 bit support, CM4 detection and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 
-project(rpi_smi_leds VERSION 2024.12.29.2
+project(rpi_smi_leds VERSION 2026.03.20.0
                      DESCRIPTION "Drive 8 or 16 LED strips on an RPI using SMI memory interface"
                      LANGUAGES C)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+In memory of Robert Kaye, creator of `smi_leds`, founder of the MetaBrainz foundation, and much more.
+
 # SMI LEDs
 
 This project allows you to drive 8 or 16 WS2812 LED strips with one single Raspberry Pi!
@@ -254,5 +256,4 @@ This module could use various improvements over time if people are interesting i
 * Consider adding gamma correction
 * Debug the set_pixel() function to allow changing single pixels
 
-Also, if someone else would like to take over the development of this module, I would be
-happy to pass it on.
+There are also lots of functions that are not optimized. Feel free to commit if you'd like to improve something!

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ out to 8 (or 16) strips. If you have 4 strips, send 4 strips of data and then
 
 ## OS Choice
 
-Currently this code only works on a 32 bit Raspberry Pi OS images. 64 bit images are
-currently not supported, but I'll see about getting those working as well.
+This project is built and tested for Raspberry Pi OS distributions. Both 32-bit and 64-bit 
+versions are supported. The project may work but is not tested on other Linux distributions.
 
 ## Raspberry Pi Setup
 

--- a/detect_rpi.py
+++ b/detect_rpi.py
@@ -5,13 +5,14 @@ import sys
 # TODO: Identify an RPI 5 and throw an error
 VERSION_STRING_MAPPING = {
     # longest strings should go first!
-    "Raspberry Pi Model A Plus": ("0x20000000", 400000000),
-    "Raspberry Pi Zero 2":       ("0x3F000000", 400000000),
-    "Raspberry Pi Zero":         ("0x20000000", 400000000),
-    "Raspberry Pi 1":            ("0x20000000", 400000000),
-    "Raspberry Pi 2":            ("0x3F000000", 250000000),
-    "Raspberry Pi 3":            ("0x3F000000", 250000000),
-    "Raspberry Pi 4":            ("0xFE000000", 250000000),
+    "Raspberry Pi Compute Module 4":    ("0xFE000000", 250000000),
+    "Raspberry Pi Model A Plus":        ("0x20000000", 400000000),
+    "Raspberry Pi Zero 2":              ("0x3F000000", 400000000),
+    "Raspberry Pi Zero":                ("0x20000000", 400000000),
+    "Raspberry Pi 1":                   ("0x20000000", 400000000),
+    "Raspberry Pi 2":                   ("0x3F000000", 250000000),
+    "Raspberry Pi 3":                   ("0x3F000000", 250000000),
+    "Raspberry Pi 4":                   ("0xFE000000", 250000000),
 }
 
 def detect_rpi_version(override):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ with open(readme, "r") as f:
     long_description=f.read()
 
 setup(name = "smileds",
-      version = "2024.12.29.2",
+      version = "2026.03.20.0",
       ext_modules = [Extension("smileds",
                                ["python/module.c",
                                "python/libsmi_leds.c",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(name = "smileds",
                                include_dirs=["include"])],
       install_requires=[ "wheel" ],
       py_modules=["detect_rpi"],
-      author="Jeremy P Bentham, Robert Kaye",
+      author="Jeremy P Bentham, Robert Kaye, infopcgood",
       classifiers=[
           "Programming Language :: Python :: 3",
           "Development Status :: 4 - Beta",

--- a/smi_leds/rpi_pixleds_lib.c
+++ b/smi_leds/rpi_pixleds_lib.c
@@ -318,7 +318,7 @@ void leds_send()
     }
 #endif
     start_smi(&vc_mem);
-    usleep(2850);
+    usleep(10);
 }
 
 void leds_set(uint8_t *buffer)

--- a/smi_leds/rpi_pixleds_lib.c
+++ b/smi_leds/rpi_pixleds_lib.c
@@ -305,7 +305,18 @@ void leds_send()
     swap_bytes(tx_buffer, TX_BUFF_SIZE(led_count));
 #endif
     //NOTE: due to caching its more efficient to use a memcpy instead of direct buffer manipulation.
+    //SECOND NOTE: the upper note only applies to 32 bit systems. On 64 bit systems, memcpy will
+    //             fail due to different memory mapping and needs to use direct buffer manipulation instead.
+    //             The current implementation is probably not the most efficient and will probably need to
+    //             be improved later.
+#ifndef __aarch64__
     memcpy(txdata, tx_buffer, TX_BUFF_SIZE(led_count));
+#else
+    for (int i=0; i<TX_BUFF_LEN(led_count); i++)
+    {
+	txdata[i] = tx_buffer[i];
+    }
+#endif
     start_smi(&vc_mem);
     usleep(2850);
 }


### PR DESCRIPTION
With a few hours of debugging I was able to track down the 64-bit 'Bus error' issue to memcpy, and with the suggestion of ChatGPT I replaced it with a simple for loop that copies all the content of one buffer to another, one by one.

This code is probably very inefficient, but I don't know about memory well enough to improve it. Further touches will be needed.

I also added a version string mapping for the Raspberry Pi Compute Module 4, and removed a seemingly meaningless 2840 μs delay.

Tested on a Raspberry Pi CM4 (RAM 8GB, eMMC 32GB) running the latest version of Raspberry Pi OS Lite (64 bit, Trixie) + CM4 IO board with one LED strip. The code successfully runs when configured for 16 strips and will display the correct colors for a single strip, but I was not able to test it with 16 LED strips as I don't have them yet.